### PR TITLE
windows implementation based on typeperf tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -44,7 +44,25 @@ AIX is tricky because I have no AIX test environement, at the moment we use: `ps
 [#4](https://github.com/soyuka/pidusage/issues/4)
 
 ### Windows
-Windows is really tricky, atm it uses the `wmic.exe`, feel free to share ideas on how to improve this.
+We use `typeperf` tool in Windows. 
+First `typeperf "\Process(*)\ID Process" -sc 1` command is run to resolve `process name` from `PID`, 
+afterwards information from `typeperf -sc 1 "\Process(<process name>)\% Processor Time" "\Process(<process name>)\Working Set"` commands output is parsed for stats report. 
+To get reports from other(extra) counters like `Working Set - Private` (which is not available in old `Windows`-es) you can provide their name in options as follows:
+
+```
+var pusage = require('pidusage')
+
+pusage.stat(process.pid, {extra : ['Virtual Bytes', 'Working Set - Private']}, function(err, stat) {
+
+	console.log('Pcpu: %s', stat.cpu) //same as parseFloat(stat.all['% Processor Time'])
+	console.log('Mem: %s', stat.memory) //same as parseFloat(stat.all['Working Set'])
+	
+	console.log('Virtual Bytes: %s', stat.all['Virtual Bytes']) 
+	console.log('Working Set - Private: %s', stat.all['Working Set - Private']) 
+
+})
+
+```
 
 # Licence
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,3 +1,4 @@
+"use strict";
 var os = require('os')
   , fs = require('fs')
   , p = require('path')
@@ -113,39 +114,75 @@ var stats = {
       })
     })
   },
-  /**
-   * This is really in a beta stage
-   */
   win: function(pid, options, done) {
 
-    // var history = this.history[pid] ? this.history[pid] : {}
-    //   , uptime = os.uptime()
-    //   , self = this
-
-    //http://social.msdn.microsoft.com/Forums/en-US/469ec6b7-4727-4773-9dc7-6e3de40e87b8/cpu-usage-in-for-each-active-process-how-is-this-best-determined-and-implemented-in-an?forum=csharplanguage
-    exec('wmic PROCESS '+pid+' get workingsetsize,usermodetime,kernelmodetime', function(error, stdout, stderr) {
-      if(error) {
-        console.log(error)
-        return done(error)
+    if (options.extra) {
+      if (!Array.isArray(options.extra)) {
+        return done('options.extra must be array') ;
       }
+    }
 
-      stdout = stdout.split(os.EOL)[1]
-      stdout = stdout.replace(/\s\s+/g, ' ').split(' ')
+    function collectStat(history) {
 
-      var stats = {
-        kernelmodetime: parseFloat(stdout[0]),
-        usermodetime: parseFloat(stdout[1]),
-        workingsetsize: parseFloat(stdout[2])
-      }
+      var command = ['% Processor Time', 'Working Set']
+        .concat(options.extra)
+        .reduce(function(val, el){
+          return val + ' '+ history._counterPrefix + '\\' + el + '"' ;
+        }, 'typeperf -sc 1');
 
-      //according to http://technet.microsoft.com/en-us/library/ee176718.aspx
-      var total = (stats.usermodetime + stats.kernelmodetime) / 10000000 //seconds
+
+      exec(command, function (error, stdout, stderr) {
+        if (error) {
+          console.log(error)
+          return done(error)
+        }
+
+        var l = stdout.replace(/[\'\"]/g,'').split(os.EOL)
+          , titles = l[1].split(',')
+          , values = l[2].split(',');
+
+        var allStats = titles.reduce(function(obj, el, index){
+          el = el.substring(el.lastIndexOf('\\')+1);
+          obj[el] = values[index];
+          return obj;
+        }, {});
 
         return done(null, {
-        cpu: total,
-        memory: stats.workingsetsize
+          cpu: parseFloat(values[1]),
+          memory: parseFloat(values[2]),
+          all: allStats
+        })
+      });
+    }
+
+    var history = this.history[pid]
+       , self = this;
+
+    if (history) { // if we already have in cache the process name as used in typeperf tool
+      collectStat(history);
+    } else {
+      exec('typeperf "\\Process(*)\\ID Process" -sc 1', function (error, stdout, stderr) {
+        if (error) {
+          console.log(error);
+          return done(error)
+        }
+        var lines = stdout.split(os.EOL)
+          , nameList = lines[1].split(',')
+          , pidList = lines[2].split(',');
+
+        var p = '"' + pid + '.';
+        for (var i = 0; i < pidList.length; i++) {
+          if (pidList[i].indexOf(p) === 0) {
+            history = self.history[pid] = {
+              _counterPrefix: nameList[i].substr(0, nameList[i].lastIndexOf('\\'))
+            };
+            break;
+          }
+        }
+        collectStat(history);
       })
-    })
+    }
+
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var pusage = require('../').stat
+  , platform = require('os').platform()
   , expect = require('chai').expect
 
 //classic "drop somewhere"... yeah I'm a lazy guy
@@ -57,4 +58,27 @@ describe('pid usage', function() {
       })
     }, 2000)
   })
-})
+
+
+  var isWindows = platform.match(/^win/);
+
+  it('should get extra process information under WINDOWS os', isWindows ? function(cb) {
+    pusage(process.pid, {extra : ['Virtual Bytes']}, function(err, stat) {
+
+      expect(err).to.be.null
+      expect(stat).to.be.an('object')
+      expect(stat).to.have.property('cpu')
+      expect(stat).to.have.property('memory')
+      expect(stat).to.have.property('all')
+      expect(stat.all).to.be.an('object')
+      expect(stat.all).to.have.property('Virtual Bytes')
+
+      console.log('Pcpu: %s', stat.cpu)
+      console.log('Mem: %s', formatBytes(stat.memory))
+      console.log('Extra: ', stat.all)
+
+      cb()
+    })
+  } : undefined)
+});
+


### PR DESCRIPTION
Please review my changes. 
It should do the same as  as ps -o pcpu,rssize -p PID  <pid> does.

The key rss (or rssize) looks same as "\Process(<name>\Working Set" counter - amount of allocated memory by the process which will not result page fault when will be accessed. Similar thing is described in ps man page for rss.

The '% Processor Time' looks like similar to pcpu (not sure though). At least it shows the percentage of cpu usage by process between 2 measurements, the interval is in milliseconds. 

Gurgen
