### PR TITLE
Use spawn instead of exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# IDEA files
+.idea
+*.iml

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -4,7 +4,6 @@ var os = require('os')
   , exec = require('child_process').exec
   , spawn = require('child_process').spawn
   , helpers = require('./helpers')
-  , debug = require('debug')('pidusage')
 
 var stats = {
   history: {},
@@ -135,13 +134,11 @@ var stats = {
       wmic.on('close', function () {
           stdout = stdout.split(os.EOL)[1];
           stdout = stdout.replace(/\s\s+/g, ' ').split(' ');
-          debug('stdout: ' + stdout);
           var stats = {
               kernelmodetime: parseFloat(stdout[0]),
               usermodetime: parseFloat(stdout[1]),
               workingsetsize: parseFloat(stdout[2])
           };
-          debug("stats: %j", stats);
           // according to http://technet.microsoft.com/en-us/library/ee176718.aspx
           var total = (stats.usermodetime + stats.kernelmodetime) / 10000000; //seconds
           return done(null, {cpu: total, memory: stats.workingsetsize});

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -2,6 +2,7 @@ var os = require('os')
   , fs = require('fs')
   , p = require('path')
   , exec = require('child_process').exec
+  , spawn = require('child_process').spawn
   , helpers = require('./helpers')
 
 var stats = {
@@ -117,35 +118,35 @@ var stats = {
    * This is really in a beta stage
    */
   win: function(pid, options, done) {
+      //  http://social.msdn.microsoft.com/Forums/en-US/469ec6b7-4727-4773-9dc7-6e3de40e87b8/cpu-usage-in-for-each-active-process-how-is-this-best-determined-and-implemented-in-an?forum=csharplanguage
+      //var wmic = spawn('wmic' ['PROCESS', pid, 'get workingsetsize,usermodetime,kernelmodetime']);
+      var wmic = spawn('wmic', ['PROCESS', pid, 'get', 'workingsetsize,usermodetime,kernelmodetime']);
+      var stdout = '';
+      wmic.stdout.on('data', function (data) {
+          stdout += data;
+      });
+      wmic.stderr.on('data', function (data) {
+          console.warn(data);
+      });
 
-    // var history = this.history[pid] ? this.history[pid] : {}
-    //   , uptime = os.uptime()
-    //   , self = this
+      wmic.on('close', function () {
+          stdout = stdout.split(os.EOL)[1];
+          stdout = stdout.replace(/\s\s+/g, ' ').split(' ');
+          var stats = {
+              kernelmodetime: parseFloat(stdout[0]),
+              usermodetime: parseFloat(stdout[1]),
+              workingsetsize: parseFloat(stdout[2])
+          };
+          // according to http://technet.microsoft.com/en-us/library/ee176718.aspx
+          var total = (stats.usermodetime + stats.kernelmodetime) / 10000000; //seconds
+          return done(null, {cpu: total, memory: stats.workingsetsize});
+      });
 
-    //http://social.msdn.microsoft.com/Forums/en-US/469ec6b7-4727-4773-9dc7-6e3de40e87b8/cpu-usage-in-for-each-active-process-how-is-this-best-determined-and-implemented-in-an?forum=csharplanguage
-    exec('wmic PROCESS '+pid+' get workingsetsize,usermodetime,kernelmodetime', function(error, stdout, stderr) {
-      if(error) {
-        console.log(error)
-        return done(error)
-      }
+      wmic.on('error', function (err) {
+          console.error("wmic spawn error: " + err);
+          return done(err);
+      });
 
-      stdout = stdout.split(os.EOL)[1]
-      stdout = stdout.replace(/\s\s+/g, ' ').split(' ')
-
-      var stats = {
-        kernelmodetime: parseFloat(stdout[0]),
-        usermodetime: parseFloat(stdout[1]),
-        workingsetsize: parseFloat(stdout[2])
-      }
-
-      //according to http://technet.microsoft.com/en-us/library/ee176718.aspx
-      var total = (stats.usermodetime + stats.kernelmodetime) / 10000000 //seconds
-
-        return done(null, {
-        cpu: total,
-        memory: stats.workingsetsize
-      })
-    })
   }
 }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -4,6 +4,7 @@ var os = require('os')
   , exec = require('child_process').exec
   , spawn = require('child_process').spawn
   , helpers = require('./helpers')
+  , debug = require('debug')('pidusage')
 
 var stats = {
   history: {},
@@ -120,7 +121,9 @@ var stats = {
   win: function(pid, options, done) {
       //  http://social.msdn.microsoft.com/Forums/en-US/469ec6b7-4727-4773-9dc7-6e3de40e87b8/cpu-usage-in-for-each-active-process-how-is-this-best-determined-and-implemented-in-an?forum=csharplanguage
       //var wmic = spawn('wmic' ['PROCESS', pid, 'get workingsetsize,usermodetime,kernelmodetime']);
-      var wmic = spawn('wmic', ['PROCESS', pid, 'get', 'workingsetsize,usermodetime,kernelmodetime']);
+      var wmic = spawn('wmic', ['PROCESS', pid, 'get', 'workingsetsize,usermodetime,kernelmodetime'],
+          {detached: true}
+      );
       var stdout = '';
       wmic.stdout.on('data', function (data) {
           stdout += data;
@@ -132,11 +135,13 @@ var stats = {
       wmic.on('close', function () {
           stdout = stdout.split(os.EOL)[1];
           stdout = stdout.replace(/\s\s+/g, ' ').split(' ');
+          debug('stdout: ' + stdout);
           var stats = {
               kernelmodetime: parseFloat(stdout[0]),
               usermodetime: parseFloat(stdout[1]),
               workingsetsize: parseFloat(stdout[2])
           };
+          debug("stats: %j", stats);
           // according to http://technet.microsoft.com/en-us/library/ee176718.aspx
           var total = (stats.usermodetime + stats.kernelmodetime) / 10000000; //seconds
           return done(null, {cpu: total, memory: stats.workingsetsize});


### PR DESCRIPTION
Passes basic mocha test case
Useful when using pm2, setting "detached: true" avoids console windows from blinking in/out when wmic is run