### PR TITLE
Get the cpu/memory info of a process from the Win32_PerfFormattedData…

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -118,7 +118,7 @@ var stats = {
   /**
    * This is really in a beta stage
    */
-  win: function(pid, options, done) {
+  win_bak: function(pid, options, done) {
       //  http://social.msdn.microsoft.com/Forums/en-US/469ec6b7-4727-4773-9dc7-6e3de40e87b8/cpu-usage-in-for-each-active-process-how-is-this-best-determined-and-implemented-in-an?forum=csharplanguage
       //var wmic = spawn('wmic' ['PROCESS', pid, 'get workingsetsize,usermodetime,kernelmodetime']);
       var wmic = spawn('wmic', ['PROCESS', pid, 'get', 'workingsetsize,usermodetime,kernelmodetime'],
@@ -150,7 +150,42 @@ var stats = {
           return done(err);
       });
 
+  },
+
+  win: function(pid, options, done) {
+      // The code is tested under:
+      // Windows 7 Ultimate/Enterprise SP1 64bit
+      // Windows 8.1 Pro SP1 64bit
+      // Windows 10 Professonal 64bit
+      // Windows Server 2008 R2 64bit
+      // Windows Server 2012 R2 64bit
+
+      // Ref:
+      // https://msdn.microsoft.com/en-us/library/aa394277(v=vs.85).aspx
+    
+      // What we get is really a small bunch of data, so exec is better here.
+      var cmd = exec( 'wmic path Win32_PerfFormattedData_PerfProc_Process WHERE IDProcess=' + pid + ' get PercentProcessorTime, WorkingSet', function( error, stdout, stderr ) {
+      if( error ) {
+        return done(err);
+      }
+      stdout = stdout.trim();
+      
+      if( !stdout ) {
+        return done( pid + ' does not exist' );
+      }
+      // The new line in Windows is '\r\r\n'
+      var lines  = stdout.split( '\r\r\n' );
+      //var titles = lines[0].trim().split( / +/ ); // We might need the titles someday.
+      var values = lines[1].trim().split( / +/ );
+      var cpuPercent = parseFloat(values[0])
+      var memUsage   = parseFloat(values[1])
+      if( isNaN( cpuPercent ) || isNaN( memUsage ) ) {
+        return done( 'Invalid cpu or memory occupation' );
+      }
+      return done( null, { cpu : cpuPercent, memory : memUsage } );
+    } );
   }
+
 }
 
 module.exports = stats;


### PR DESCRIPTION
All the processes's info including CPU processing time, memory usage(working set, peak working set, etc) can be accessed from the Win32_PerfFormattedData_PerfProc_Process object with WMIC, so it's a good way to get the things by the command:

```
wmic path Win32_PerfFormattedData_PerfProc_Process WHERE IDProcess=THE_PID get PercentProcessorTime, WorkingSet
```