### PR TITLE
Need to check for utime undefined; otherwise processes with utime=0 (…

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -67,7 +67,7 @@ var stats = {
       var childrens = options.childrens ? stat.cutime + stat.cstime : 0
       var total = 0;
 
-      if(history.utime) {
+      if(typeof history.utime !== 'undefined') {
         total = (stat.stime - history.stime) + (stat.utime - history.utime) + childrens
       } else {
         total = stat.stime + stat.utime + childrens

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -65,13 +65,8 @@ var stats = {
       //http://stackoverflow.com/questions/16726779/total-cpu-usage-of-an-application-from-proc-pid-stat/16736599#16736599
 
       var childrens = options.childrens ? stat.cutime + stat.cstime : 0
-      var total = 0;
-
-      if(typeof history.utime !== 'undefined') {
-        total = (stat.stime - history.stime) + (stat.utime - history.utime) + childrens
-      } else {
-        total = stat.stime + stat.utime + childrens
-      }
+      
+      var total = stat.stime - (history.stime || 0) + stat.utime - (history.utime || 0) + childrens
 
       total = total / cpu.clock_tick
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "~3.4.1",
-    "mocha": "~2.3.4"
+    "mocha": "~2.3.4",
+    "mockery": "1.4.0"
   },
   "scripts": {
     "test": "mocha test/test.js --reporter min"

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
-var pusage = require('../').stat
-  , expect = require('chai').expect
+var mockery = require('mockery'),
+    expect = require('chai').expect,
+    os = require('os')
 
 //classic "drop somewhere"... yeah I'm a lazy guy
 var formatBytes = function(bytes, precision) {
@@ -26,7 +27,21 @@ var formatBytes = function(bytes, precision) {
 describe('pid usage', function() {
   this.timeout(10000)
 
+  beforeEach(function() {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+  });
+
+  afterEach(function() {
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
   it('should get pid usage', function(cb) {
+    var pusage = require('../').stat;
     pusage(process.pid, function(err, stat) {
 
       expect(err).to.be.null
@@ -42,6 +57,7 @@ describe('pid usage', function() {
   })
 
   it('should get pid usage again', function(cb) {
+    var pusage = require('../').stat;
     setTimeout(function() {
       pusage(process.pid, function(err, stat) {
 
@@ -57,4 +73,64 @@ describe('pid usage', function() {
       })
     }, 2000)
   })
+
+  it('should calculate correct cpu when user space time is zero (kernel module)', function(cb) {
+    // force platform to linux to test this case
+    var os = require('os');
+    os.platform = function() {
+      return 'linux';
+    };
+
+    // override readFile to simulate the system time only (kernel module) case
+    var fs = require('fs');
+    var clock_tick = 100;
+    
+    fs.readFile = function(path, encoding, callback) {
+      if(path === '/proc/uptime') {
+        callback(null, '0 0');
+      } else { // proc/<pid>/stat
+        var infos = '0 (test)';
+        for(var i = 0; i < 22; i++) {
+          if(i === 12) {
+            infos += ' '+currentStime;
+          } else {
+            infos += ' 0';  
+          }
+          
+        }
+        callback(null, infos);  
+      }
+    };
+
+    var helpers = require('../lib/helpers');
+    helpers.cpu = function(next) {
+      next(null, {
+          clock_tick: clock_tick,
+          uptime: clock_tick,
+          pagesize: 4096
+        })
+    }
+
+    // mock out to simulate kernel module and linux platform
+    mockery.registerMock('fs', fs);
+    mockery.registerMock('os', os);
+    mockery.registerMock('./helpers.js', helpers);
+    
+    var pusage = require('..');
+    // set the previous history as if kernel module usage had been called before
+    var kernel_module_pid = 0;
+    var currentStime = 10000*clock_tick;
+    var previousStime = 2000*clock_tick;
+    
+    pusage._history[kernel_module_pid] = {};
+    pusage._history[kernel_module_pid].uptime = 0;
+    pusage._history[kernel_module_pid].utime = 0;
+    pusage._history[kernel_module_pid].stime = previousStime;
+    
+    pusage.stat(kernel_module_pid, function(err, stat) {
+      expect(stat.cpu).to.be.equal((currentStime - previousStime)/clock_tick);
+      cb();
+    });
+  });
+
 })


### PR DESCRIPTION
…i.e. kernel modules) are not properly calculated relative to history