### PR TITLE
callback called twice on Windows

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -161,7 +161,7 @@ var stats = {
     })
 
     wmic.on('error', function(err) {
-      done(err, null)
+      console.error(err.toString())
     })
   }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -129,7 +129,7 @@ var stats = {
   
     var args = 'path Win32_PerfFormattedData_PerfProc_Process WHERE IDProcess=' + pid + ' get PercentProcessorTime, WorkingSet'
     var wmic = spawn('wmic', args.split(' '), {detached: true})
-    var stdout = ''
+    var stdout = '', error = false;
 
     wmic.stdout.on('data', function(d) {
      stdout += d.toString() 
@@ -144,6 +144,8 @@ var stats = {
       
       if(!stdout)
         return done(new Error(pid + ' does not exist'), null)
+			else if (error)
+				return ;
 
       // The new line in Windows is '\r\r\n'
       var lines = stdout.split(/\r?\r\n/)
@@ -161,7 +163,8 @@ var stats = {
     })
 
     wmic.on('error', function(err) {
-      console.error(err.toString())
+				error = true;
+      	done(err, null);
     })
   }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -143,7 +143,7 @@ var stats = {
       stdout = stdout.trim()
       
       if(!stdout)
-        return done(new Error(pid + ' does not exist', null))
+        return done(new Error(pid + ' does not exist'), null)
 
       // The new line in Windows is '\r\r\n'
       var lines = stdout.split(/\r?\r\n/)


### PR DESCRIPTION
On Windows, its happen that error event and close event are both called, that result on callback function called twice

(sorry for tabs bug)