### PR TITLE
Support NetBSD via its Linux-compatible procfs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var pusage = {
   darwin: wrapper('ps'),
   sunos: wrapper('ps'),
   freebsd: wrapper('ps'),
+  netbsd: wrapper('proc'),
   win: wrapper('win'),
   linux: wrapper('proc'),
   aix: wrapper('ps'),


### PR DESCRIPTION
Hi,
All that is needed for pidusage to support NetBSD is to map it to the 'proc' handler. NetBSD has a procfs that is fully compatible with the Linux format, including `/proc/uptime` and `/proc/<pid>/stat` with the same format that Linux has. So it all just works!

It'd be great to get this merged please so that other tools using `pidusage` (such as `pm2`) can get CPU and memory info on NetBSD.

Cheers,

Timshel

![image](https://cloud.githubusercontent.com/assets/8703183/22446513/4d76fd0e-e7a1-11e6-9585-ded03d87fabf.png)
