### PR TITLE
Improve performance on windows

### DIFF
--- a/lib/wmic.js
+++ b/lib/wmic.js
@@ -45,7 +45,7 @@ function wmic (pids, options, done) {
     'CreationDate,KernelModeTime,ParentProcessId,ProcessId,UserModeTime,WorkingSetSize'
   ]
 
-  bin('wmic', args, {windowsHide: true, windowsVerbatimArguments: true}, function (err, stdout, code) {
+  bin('wmic', args, {windowsVerbatimArguments: true}, function (err, stdout, code) {
     if (err) {
       if (err.message.indexOf('No Instance(s) Available.') !== -1) {
         return done(new Error('No maching pid found'))


### PR DESCRIPTION
It seems that the `windowsHide: true` on windows cause the spawn of two processes.