### PR TITLE
Fix stat.time

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -82,11 +82,11 @@ function readProcFile (pid, options, done) {
       // In kernels before Linux 2.6, start was expressed in jiffies. Since Linux 2.6, the value is expressed in clock ticks
       var stat = {
         ppid: parseInt(infos[1]),
-        utime:  parseFloat(infos[11]) * 1000 / cpuInfo.clockTick,
-        stime:  parseFloat(infos[12]) * 1000 / cpuInfo.clockTick,
+        utime: parseFloat(infos[11]) * 1000 / cpuInfo.clockTick,
+        stime: parseFloat(infos[12]) * 1000 / cpuInfo.clockTick,
         cutime: parseFloat(infos[13]) * 1000 / cpuInfo.clockTick,
         cstime: parseFloat(infos[14]) * 1000 / cpuInfo.clockTick,
-        start:  parseFloat(infos[19]) * 1000 / cpuInfo.clockTick,
+        start: parseFloat(infos[19]) * 1000 / cpuInfo.clockTick,
         rss: parseFloat(infos[21]),
         uptime: cpuInfo.uptime * 1000,
         fd: fd

--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -82,13 +82,13 @@ function readProcFile (pid, options, done) {
       // In kernels before Linux 2.6, start was expressed in jiffies. Since Linux 2.6, the value is expressed in clock ticks
       var stat = {
         ppid: parseInt(infos[1]),
-        utime: parseFloat(infos[11]),
-        stime: parseFloat(infos[12]),
-        cutime: parseFloat(infos[13]),
-        cstime: parseFloat(infos[14]),
-        start: parseFloat(infos[19]) / cpuInfo.clockTick,
+        utime:  parseFloat(infos[11]) * 1000 / cpuInfo.clockTick,
+        stime:  parseFloat(infos[12]) * 1000 / cpuInfo.clockTick,
+        cutime: parseFloat(infos[13]) * 1000 / cpuInfo.clockTick,
+        cstime: parseFloat(infos[14]) * 1000 / cpuInfo.clockTick,
+        start:  parseFloat(infos[19]) * 1000 / cpuInfo.clockTick,
         rss: parseFloat(infos[21]),
-        uptime: cpuInfo.uptime,
+        uptime: cpuInfo.uptime * 1000,
         fd: fd
       }
 
@@ -97,7 +97,7 @@ function readProcFile (pid, options, done) {
       // https://stackoverflow.com/a/16736599/3921589
       var childrens = options.childrens ? stat.cutime + stat.cstime : 0
       // process usage since last call in seconds
-      var total = (stat.stime - (hst.stime || 0) + stat.utime - (hst.utime || 0) + childrens) / cpuInfo.clockTick
+      var total = (stat.stime - (hst.stime || 0) + stat.utime - (hst.utime || 0) + childrens)
       // time elapsed between calls in seconds
       var seconds = Math.abs(hst.uptime !== undefined ? stat.uptime - hst.uptime : stat.start - stat.uptime)
       var cpu = seconds > 0 ? (total / seconds) * 100 : 0
@@ -111,8 +111,8 @@ function readProcFile (pid, options, done) {
       return done(null, {
         cpu: cpu,
         memory: memory,
-        ctime: (stat.utime + stat.stime) / cpuInfo.clockTick,
-        elapsed: (stat.uptime * 1000) - (stat.start * 1000), // process uptime minus start time
+        ctime: stat.utime + stat.stime,
+        elapsed: stat.uptime - stat.start,
         timestamp: date,
         pid: pid,
         ppid: stat.ppid


### PR DESCRIPTION
To fix issue #87 .
Correct time unit to be ms.
Tested well on Ubuntu 18.