### PR TITLE
Remove interval task in lib/history.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Get pid informations.
 
 ### pidusage.clear()
 
-If needed this function can be used to clear the event loop. Indeed, we're registering an interval to free up the in-memory metrics. By calling this, it will clear this interval and all delete all in-memory data.
+If needed this function can be used to delete all in-memory metrics.
 
 ## Related
 - [pidusage-tree][gh:pidusage-tree] -

--- a/lib/history.js
+++ b/lib/history.js
@@ -5,16 +5,18 @@ var expiration = {}
 var history = {}
 var expireListeners = {}
 
-var size = 0
-var interval = null
+var last = 0;
 
 function get (pid, maxage) {
   if (maxage <= 0) {
     return
   }
 
+  var now = Date.now()
+  runInvalidator(now)
+
   if (history[pid] !== undefined) {
-    expiration[pid] = Date.now() + (maxage || DEFAULT_MAXAGE)
+    expiration[pid] = now + (maxage || DEFAULT_MAXAGE)
   }
 
   return history[pid]
@@ -23,11 +25,9 @@ function get (pid, maxage) {
 function set (pid, object, maxage, onExpire) {
   if (object === undefined || maxage <= 0) return
 
-  expiration[pid] = Date.now() + (maxage || DEFAULT_MAXAGE)
-  if (history[pid] === undefined) {
-    size++
-    sheduleInvalidator(maxage)
-  }
+  var now = Date.now()
+  expiration[pid] = now + (maxage || DEFAULT_MAXAGE)
+  runInvalidator(now)
 
   history[pid] = object
   if (onExpire) {
@@ -35,28 +35,14 @@ function set (pid, object, maxage, onExpire) {
   }
 }
 
-function sheduleInvalidator (maxage) {
-  if (size > 0) {
-    if (interval === null) {
-      interval = setInterval(runInvalidator, (maxage || DEFAULT_MAXAGE) / 2)
-    }
+function runInvalidator (now) {
+  if (now - last < 1000) return
+  last = now
 
-    return
-  }
-
-  if (interval !== null) {
-    clearInterval(interval)
-    interval = null
-  }
-}
-
-function runInvalidator () {
-  var now = Date.now()
   var pids = Object.keys(expiration)
   for (var i = 0; i < pids.length; i++) {
     var pid = pids[i]
     if (expiration[pid] < now) {
-      size--
       if (expireListeners[pid]) {
         expireListeners[pid](history[pid])
       }
@@ -66,17 +52,11 @@ function runInvalidator () {
       delete expireListeners[pid]
     }
   }
-  sheduleInvalidator()
 }
 
 function deleteLoop (obj) { for (const i in obj) { delete obj[i] } }
 
 function clear () {
-  if (interval !== null) {
-    clearInterval(interval)
-    interval = null
-  }
-
   deleteLoop(history)
   deleteLoop(expiration)
   deleteLoop(expireListeners)

--- a/test/integration.js
+++ b/test/integration.js
@@ -112,7 +112,7 @@ test('should throw an error if the pid is too large', async t => {
   await t.throwsAsync(() => m(99999999))
 })
 
-test.cb('should exit right away because we cleaned up the event loop', t => {
+test.cb('should exit right after calling clear', t => {
   if (os.platform().match(/^win/)) return t.end()
 
   const start = Date.now()
@@ -126,7 +126,7 @@ test.cb('should exit right away because we cleaned up the event loop', t => {
   })
 })
 
-test.cb('should exit after a few seconds because the event loop is busy with history', t => {
+test.cb('should exit right away without calling clear', t => {
   if (os.platform().match(/^win/)) return t.end()
 
   const start = Date.now()
@@ -134,7 +134,7 @@ test.cb('should exit after a few seconds because the event loop is busy with his
 
   f.on('exit', function (code) {
     const end = Date.now()
-    t.true(end - start > 1000)
+    t.true(end - start < 1000)
     t.is(code, 0)
     t.end()
   })


### PR DESCRIPTION
Run the history invalidation task on set and get instead of scheduling it on an interval.

This is a more invasive and potentially breaking alternative to #107.