### PR TITLE
Unref history interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Get pid informations.
 
 ### pidusage.clear()
 
-If needed this function can be used to clear the event loop. Indeed, we're registering an interval to free up the in-memory metrics. By calling this, it will clear this interval and all delete all in-memory data.
+If needed this function can be used to delete all in-memory metrics and clear the event loop. This is not necessary before exiting as the interval we're registring does not hold up the event loop.
 
 ## Related
 - [pidusage-tree][gh:pidusage-tree] -

--- a/lib/history.js
+++ b/lib/history.js
@@ -39,6 +39,7 @@ function sheduleInvalidator (maxage) {
   if (size > 0) {
     if (interval === null) {
       interval = setInterval(runInvalidator, (maxage || DEFAULT_MAXAGE) / 2)
+      interval.unref()
     }
 
     return

--- a/test/integration.js
+++ b/test/integration.js
@@ -126,7 +126,7 @@ test.cb('should exit right away because we cleaned up the event loop', t => {
   })
 })
 
-test.cb('should exit after a few seconds because the event loop is busy with history', t => {
+test.cb('should exit right away because the event loop ignores history', t => {
   if (os.platform().match(/^win/)) return t.end()
 
   const start = Date.now()
@@ -134,7 +134,7 @@ test.cb('should exit after a few seconds because the event loop is busy with his
 
   f.on('exit', function (code) {
     const end = Date.now()
-    t.true(end - start > 1000)
+    t.true(end - start < 1000)
     t.is(code, 0)
     t.end()
   })


### PR DESCRIPTION
Call unref() on the interval created by lib/history.js so that it does not prevent the event loop for exiting.  Relieves the need to call pidusage.clear() before exiting in applications using the library.

This is a simpler alternative to #106.