### PR TITLE
fall back to date if uptime unavailable

### DIFF
--- a/lib/wmic.js
+++ b/lib/wmic.js
@@ -61,7 +61,7 @@ function wmic (pids, options, done) {
 
     // Note: On Windows the returned value includes fractions of a second.
     // Use Math.floor() to get whole seconds.
-    var uptime = Math.floor(os.uptime())
+    var uptime = Math.floor(os.uptime() || (date/1000))
 
     // Example of stdout on Windows 10
     // CreationDate: is in the format yyyymmddHHMMSS.mmmmmmsUUU


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master, as there's no other stable branch I can see?
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | might relate to #76


Users may not have permissions to get system uptime, in which case `os.uptime()` will return `undefined`.

(had a case on Windows Server, where a service with limited permissions exhibited a weird bug related to this)