### PR TITLE
Add initial z/OS (os390) support

### DIFF
--- a/lib/ps.js
+++ b/lib/ps.js
@@ -43,7 +43,17 @@ function ps (pids, options, done) {
   }
 
   bin('ps', args, function (err, stdout, code) {
-    if (err) return done(err)
+    if (err) {
+      // Exceptional case for os390:
+      if (PLATFORM === 'os390') {
+        if (err == "Error: ps: FSUMA904 no matching processes found.\n") {
+          const error = new Error('No matching pid found')
+          error.code = 'ENOENT'
+          return done(error)
+        }
+      }
+      return done(err)
+    }
     if (code === 1) {
       const error = new Error('No matching pid found')
       error.code = 'ENOENT'

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -9,6 +9,7 @@ var platformToMethod = {
   alpine: 'procfile',
   darwin: 'ps',
   freebsd: 'ps',
+  os390: 'ps',
   linux: 'procfile',
   netbsd: 'procfile',
   sunos: 'ps',

--- a/test/integration.js
+++ b/test/integration.js
@@ -17,7 +17,9 @@ test('should work with a single pid', async t => {
   t.is(typeof result.cpu, 'number', 'cpu')
   t.false(isNaN(result.cpu), 'cpu')
   t.is(typeof result.memory, 'number', 'memory')
-  t.false(isNaN(result.memory), 'memory')
+  // z/OS does not report memory
+  if (process.platform != "os390")
+    t.false(isNaN(result.memory), 'memory')
   t.is(typeof result.ppid, 'number', 'ppid')
   t.false(isNaN(result.ppid), 'ppid')
   t.is(typeof result.pid, 'number', 'pid')
@@ -67,7 +69,12 @@ test('should work with an array of pids', async t => {
     t.is(typeof result[pid].cpu, 'number', 'cpu')
     t.false(isNaN(result[pid].cpu), 'cpu')
     t.is(typeof result[pid].memory, 'number', 'memory')
-    t.false(isNaN(result[pid].memory), 'memory')
+    // z/OS does not report memory
+    if (process.platform != "os390")
+      t.false(isNaN(result.memory), 'memory')
+    // z/OS does not report memory
+    if (process.platform != "os390")
+      t.false(isNaN(result[pid].memory), 'memory')
     t.is(typeof result[pid].ppid, 'number', 'ppid')
     t.false(isNaN(result[pid].ppid), 'ppid')
     t.is(typeof result[pid].pid, 'number', 'pid')


### PR DESCRIPTION
* Adds initial support for z/OS in pidusage, which is a dependency for pm2
* Uses the ps utility.
* Future: update to use /proc/<pid>/stat when USS adds this support