### PR TITLE
Add env vars that set the pidusage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,17 @@ Get pid informations.
 | Param | Type | Description |
 | --- | --- | --- |
 | pids | <code>Number</code> \| <code>Array.&lt;Number&gt;</code> \| <code>String</code> \| <code>Array.&lt;String&gt;</code> | A pid or a list of pids. |
+| [options] | <code>object</code> | Options object. See the table below. |
 | [callback] | <code>function</code> | Called when the statistics are ready. If not provided a promise is returned instead. |
+
+### options
+
+Setting the options programatically will override environment variables
+
+| Param | Type | Environment variable | Default | Description |
+| --- | --- | --- | --- | --- |
+| [usePs] | <code>boolean</code> | `PIDUSAGE_USE_PS`| `false` | When true uses `ps` instead of proc files to fetch process information |
+| [maxage] | <code>number</code> | `PIDUSAGE_MAXAGE`| `60000` | Max age of a process on history. |
 
 ### pidusage.clear()
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ function pidusage (pids, options, callback) {
     options = {}
   }
 
+  options = Object.assign({
+    usePs: process.env.PIDUSAGE_USE_PS,
+    maxage: process.env.PIDUSAGE_MAXAGE
+  }, options)
+
   if (typeof callback === 'function') {
     stats(pids, options, callback)
     return

--- a/test/ps.js
+++ b/test/ps.js
@@ -153,3 +153,22 @@ test('should parse ps output on *nix', async t => {
   // mockery.deregisterMock('child_process')
   // mockery.deregisterMock('os')
 })
+
+test('should be able to set usePs from env var', async t => {
+  let usePsFromStats
+
+  mockery.registerMock('./lib/stats', (_, options) => {
+    usePsFromStats = !!options.usePs
+  })
+
+  const beforeValue = process.env.PIDUSAGE_USE_PS
+  process.env.PIDUSAGE_USE_PS = '1'
+
+  const pidusage = require('../')
+  pidusage(1, () => {})
+
+  t.is(usePsFromStats, true)
+
+  process.env.PIDUSAGE_USE_PS = beforeValue
+  mockery.deregisterMock('./lib/stats')
+})


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Bug fix?      | no <!-- please update CHANGELOG.md file -->
| New feature?  | yes <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Fix #126 
| License       | MIT
| Doc PR        |  Added to README.md

Adds a way to change how pidusage works machine/container-wide. It was one of the suggestions (the most reliable one) in #126 thread.
