### PR TITLE
Allow PIDUSAGE_USE_PS to have string type of "true"

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function pidusage (pids, options, callback) {
   }
 
   options = Object.assign({
-    usePs: process.env.PIDUSAGE_USE_PS,
+    usePs: /^true$/i.test(process.env.PIDUSAGE_USE_PS),
     maxage: process.env.PIDUSAGE_MAXAGE
   }, options)
 

--- a/test/ps.js
+++ b/test/ps.js
@@ -158,11 +158,11 @@ test('should be able to set usePs from env var', async t => {
   let usePsFromStats
 
   mockery.registerMock('./lib/stats', (_, options) => {
-    usePsFromStats = !!options.usePs
+    usePsFromStats = options.usePs
   })
 
   const beforeValue = process.env.PIDUSAGE_USE_PS
-  process.env.PIDUSAGE_USE_PS = '1'
+  process.env.PIDUSAGE_USE_PS = 'true'
 
   const pidusage = require('../')
   pidusage(1, () => {})


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Bug fix?      | no 
| New feature?  | no (well, maybe - I really small one)
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 

I have been using `pm2` on DigitalOcean and wanted to set `process.env.PIDUSAGE_USE_PS` as per the discussion here https://github.com/Unitech/pm2/issues/5045. But because we are using Node and in Node environment variables are always strings, this comparison below fails for `"true" === true` or `"1" === true` etc. 
https://github.com/soyuka/pidusage/blob/61f63bd9e8f576c4b7b673171dc7262bd3c26ae8/lib/stats.js#L50

The code below make it work for `"true"`. 