### PR TITLE
Add explicit IBM i support

### DIFF
--- a/lib/ps.js
+++ b/lib/ps.js
@@ -38,7 +38,7 @@ function ps (pids, options, done) {
   const pArg = pids.join(',')
   let args = ['-o', 'etime,pid,ppid,pcpu,rss,time', '-p', pArg]
 
-  if (PLATFORM === 'aix') {
+  if (PLATFORM === 'aix' || PLATFORM === 'os400') {
     args = ['-o', 'etime,pid,ppid,pcpu,rssize,time', '-p', pArg]
   }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -5,6 +5,7 @@ const os = require('os')
 
 const platformToMethod = {
   aix: 'ps',
+  os400: 'ps',
   android: 'procfile',
   alpine: 'procfile',
   darwin: 'ps',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #
| License       | MIT
| Doc PR        | api-platform/docs#

Until Node v18, IBM i claimed to be AIX so the existing AIX code path just worked, but now the platform returned is "os400". Copy the existing AIX code paths for IBM i.

Tests passed:
```
  15 tests passed
----------------------|---------|----------|---------|---------|-------------------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s             
----------------------|---------|----------|---------|---------|-------------------------------
All files             |   86.09 |    72.55 |    92.3 |   87.64 |                               
 pidusage             |     100 |      100 |     100 |     100 |                               
  index.js            |     100 |      100 |     100 |     100 |                               
 pidusage/lib         |   86.73 |    73.29 |    87.5 |    87.9 |                               
  bin.js              |      72 |       50 |      60 |   78.26 | 27,31-33,41                   
  history.js          |   94.11 |    81.25 |     100 |   95.83 | 13,64                         
  procfile.js         |   81.81 |    63.88 |   83.33 |   82.81 | 18-19,33-34,39-40,58-61,65,70 
  ps.js               |   91.22 |    79.48 |     100 |    90.9 | 47-52,60                      
  stats.js            |   91.17 |    86.36 |     100 |    90.9 | 29,53,57                      
  wmic.js             |   85.24 |     62.5 |     100 |    86.2 | 37,50-55,58,88                
 pidusage/lib/helpers |   79.36 |    65.21 |     100 |   83.05 |                               
  cpu.js              |   70.73 |    45.83 |     100 |   76.31 | 44-47,71-72,77-80,89          
  parallel.js         |   95.45 |    86.36 |     100 |   95.23 | 21                            
----------------------|---------|----------|---------|---------|-------------------------------
```