### PR TITLE
Add compatibility with ps from BusyBox

### DIFF
--- a/lib/ps.js
+++ b/lib/ps.js
@@ -35,26 +35,15 @@ function parseTime (timestr, centisec) {
   * @param  {Function} done(err, stat)
   */
 function ps (pids, options, done) {
-  const pArg = pids.join(',')
-  let args = ['-o', 'etime,pid,ppid,pcpu,rss,time', '-p', pArg]
+  let args = ['-o', 'etime,pid,ppid,pcpu,rss,time']
 
   if (PLATFORM === 'aix' || PLATFORM === 'os400') {
-    args = ['-o', 'etime,pid,ppid,pcpu,rssize,time', '-p', pArg]
+    args = ['-o', 'etime,pid,ppid,pcpu,rssize,time']
   }
 
   bin('ps', args, function (err, stdout, code) {
     if (err) {
-      if (PLATFORM === 'os390' && /no matching processes found/.test(err)) {
-        err = new Error('No matching pid found')
-        err.code = 'ENOENT'
-      }
-
       return done(err)
-    }
-    if (code === 1) {
-      const error = new Error('No matching pid found')
-      error.code = 'ENOENT'
-      return done(error)
     }
     if (code !== 0) {
       return done(new Error('pidusage ps command exited with code ' + code))
@@ -102,6 +91,11 @@ function ps (pids, options, done) {
       }
 
       const pid = parseInt(line[1], 10)
+
+      if (!pids.includes(pid)) {
+        continue
+      }
+
       let hst = history.get(pid, options.maxage)
       if (hst === undefined) hst = {}
 
@@ -126,6 +120,12 @@ function ps (pids, options, done) {
       }
 
       history.set(pid, statistics[pid], options.maxage)
+    }
+
+    if (Object.keys(statistics).length === 0) {
+      const error = new Error('No matching pid found')
+      error.code = 'ENOENT'
+      return done(error)
     }
 
     done(null, statistics)

--- a/test/ps.js
+++ b/test/ps.js
@@ -45,7 +45,7 @@ test('should parse ps output on Darwin', async t => {
 
   const ps = require('../lib/ps')
 
-  const result = await pify(ps)([348932], {})
+  const result = await pify(ps)([430, 7166], {})
   t.deepEqual(result, {
     430: {
       cpu: (93784070 / 319853000) * 100,
@@ -54,24 +54,6 @@ test('should parse ps output on Darwin', async t => {
       pid: 430,
       ctime: (1 * 86400 + 2 * 3600 + 3 * 60 + 4 * 1) * 1000 + (10 * 7),
       elapsed: (2 * 86400 + 40 * 3600 + 50 * 60 + 53 * 1) * 1000,
-      timestamp: 864000000
-    },
-    432: {
-      cpu: (90123100 / 147053000) * 100,
-      memory: 2364 * 1024,
-      ppid: 430,
-      pid: 432,
-      ctime: (1 * 86400 + 1 * 3600 + 2 * 60 + 3 * 1) * 1000 + (10 * 10),
-      elapsed: (40 * 3600 + 50 * 60 + 53 * 1) * 1000,
-      timestamp: 864000000
-    },
-    727: {
-      cpu: (867260 / 6650000) * 100,
-      memory: 348932 * 1024,
-      ppid: 1,
-      pid: 727,
-      ctime: (14 * 60 + 27 * 1) * 1000 + (10 * 26),
-      elapsed: (1 * 3600 + 50 * 60 + 50 * 1) * 1000,
       timestamp: 864000000
     },
     7166: {
@@ -110,7 +92,7 @@ test('should parse ps output on *nix', async t => {
   //
   // const ps = require('../lib/ps')
   //
-  // const result = await pify(ps)([11678], {})
+  // const result = await pify(ps)([430, 7166], {})
   // t.deepEqual(result, {
   //   430: {
   //     cpu: 3.0,
@@ -119,24 +101,6 @@ test('should parse ps output on *nix', async t => {
   //     pid: 430,
   //     ctime: (1 * 86400 + 2 * 3600 + 3 * 60 + 4 * 1) * 1000,
   //     elapsed: (2 * 86400 + 40 * 3600 + 50 * 60 + 53 * 1) * 1000,
-  //     timestamp: 864000000
-  //   },
-  //   432: {
-  //     cpu: 0.0,
-  //     memory: 2364 * 1024,
-  //     ppid: 430,
-  //     pid: 432,
-  //     ctime: (1 * 86400 + 1 * 3600 + 2 * 60 + 3 * 1) * 1000,
-  //     elapsed: (40 * 3600 + 50 * 60 + 53 * 1) * 1000,
-  //     timestamp: 864000000
-  //   },
-  //   727: {
-  //     cpu: 10.0,
-  //     memory: 348932 * 1024,
-  //     ppid: 1,
-  //     pid: 727,
-  //     ctime: (14 * 60 + 27 * 1) * 1000,
-  //     elapsed: (1 * 3600 + 50 * 60 + 50 * 1) * 1000,
   //     timestamp: 864000000
   //   },
   //   7166: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current stable version branch for bug fixes (cannot see branch)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `ps` implementation of BusyBox doesn't support the `-p` argument. This PR replaces the usage of `-p` to own filter logic in the line processing loop. This allows `pidusage` with `ps` to work on BusyBox based platforms like Alpine Linux.