### PR TITLE
Fix spawned wmic processes not exiting when using pidusage in packaged apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.0.1
+
+- fix spawned wmic processes not exiting after wmic/gwmi detection in packaged apps, leading to infinite build up of "WMI Commandline Utility" processes and system instability
+
 ### 4.0.0
 
 - fix wmic removed on Windows 11 and add gwmi support

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -61,12 +61,17 @@ function get (pids, options, callback) {
   }
   if (platform === 'win') {
     // TODO: use https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/where to avoid try/catch
+    let child;
     try {
-      spawn('wmic', function (err) {
+      child = spawn('wmic', function (err) {
         if (err) throw new Error(err)
       })
     } catch (err) {
       fn = requireMap.gwmi()
+    } finally {
+      if (child) {
+        child.kill()
+      }
     }
   }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

With the recent addition of gwmi support on Windows, a `spawn` call was introduced to check for availability of wmic and switch to gwmi on failure.

This works fine by default, but introduces a new problem in cases where pidusage is being utilized in a packaged application such as with a tool like [pkg](https://github.com/vercel/pkg) or its actively maintained [successor fork](https://github.com/yao-pkg/pkg). In a packaged app, the spawned WMI processes don't get killed, which leads to a situation where each pidusage call creates a new process and they just infinitely stack up until the computer becomes unstable and/or runs out of memory.

I am someone who uses pidusage in packaged applications, so I found a simple solution to address this and created this PR. I modified lib/stats.js to now hold a reference to the spawned child wmic process, and I added a call to kill it in a finally block added to the try/catch. This maintains existing functionality while ensuring the child process is killed when this try/catch check is completed and works in both packaged and non-packaged environments.

For reference, this is what the task manager will look like when this situation occurs, with a new process forming on each pidusage call:

![image](https://github.com/user-attachments/assets/831a006e-a406-47b7-8d82-78e4351b6e3c)